### PR TITLE
feat: add config for better env management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .DS_Store
 .env
 db/*
+config/development.json

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ If you haven't already created a Snyk App, you can do so via:
 
 (note the extra `--` between `create-app` and the parameters)
 
-* `authToken`: your personal Snyk auth token, obtained from [your account settings page](https://app.snyk.io/account)
-* `orgId`: the organization id that you want to own the Snyk App (obtained by clicking the cog in the upper right corner of the Snyk console)
-* `scopes`: a comma separated list of scopes you want your App to be able to request at install time (see Snyk Apps docs for allowed values)
-* `name`: the friendly name of your Snyk App
+- `authToken`: your personal Snyk auth token, obtained from [your account settings page](https://app.snyk.io/account)
+- `orgId`: the organization id that you want to own the Snyk App (obtained by clicking the cog in the upper right corner of the Snyk console)
+- `scopes`: a comma separated list of scopes you want your App to be able to request at install time (see Snyk Apps docs for allowed values)
+- `name`: the friendly name of your Snyk App
 
 This will register your new app with Snyk and create the `.env` file (see below) with your new client-id & client-secret. Keep these values secure!
 
@@ -40,3 +40,12 @@ Test to confirm, go to: [http://localhost:3000](http://localhost:3000).
 The `.env` file is used to store all the environmental variables. Ensure this remains secret!
 
 If you've already created a Snyk App, you can copy `.env.example` and set the values.
+
+### Overriding the default API URLs
+
+The defaults for the required API URLs are in the `./config/default.json` file. To override this you can create an
+environment specific file. For example create a file `./config/development.json` and override the values you want to.
+Now when `NODE_ENV` is set to `development` overrided values from `./config/development.json` will be used instead.
+
+You can do the same for any other environment such as `production` or even map variables to environment variables.
+Read more about it [node-config](https://github.com/lorenwest/node-config/wiki/Environment-Variables).

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,0 +1,9 @@
+{
+    "client": {
+        "id": "CLIENT_ID",
+        "secret": "CLIENT_SECRET"
+    },
+    "ecryptionSecret": "ENCRYPTION_SECRET",
+    "redirectUri": "REDIRECT_URI",
+    "scopes": "SCOPES"
+}

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,9 @@
+{
+    "api": {
+        "base": "https://api.snyk.io"
+    },
+    "app": {
+        "base": "https://app.snyk.io"
+    },
+    "port": 3000
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1726,6 +1726,12 @@
         "@types/node": "*"
       }
     },
+    "@types/config": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/config/-/config-0.0.39.tgz",
+      "integrity": "sha512-EBHj9lSIyw62vwqCwkeJXjiV6C2m2o+RJZlRWLkHduGYiNBoMXcY6AhSLqjQQ+uPdrPYrOMYvVa41zjo00LbFQ==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -2555,6 +2561,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "config": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.6.tgz",
+      "integrity": "sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==",
+      "requires": {
+        "json5": "^2.1.1"
+      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -4825,7 +4839,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -5008,8 +5021,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
+    "@types/config": "0.0.39",
     "@types/cryptr": "^4.0.1",
     "@types/ejs": "^3.1.0",
     "@types/express": "^4.17.13",
@@ -45,6 +46,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.15.0",
     "axios": "^0.21.4",
+    "config": "^3.3.6",
     "cryptr": "^6.0.2",
     "dotenv": "^10.0.0",
     "ejs": "^3.1.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,10 +8,11 @@ import { join } from 'path';
 import type { Application } from 'express';
 import type { Server } from 'http';
 import type { Controller } from './lib/types';
-import { Envars } from './lib/types';
+import { Envars, Config } from './lib/types';
+import config from 'config';
 
-export const API_BASE = 'https://api.snyk.io';
-export const APP_BASE = 'https://app.snyk.io';
+export const API_BASE = config.get(Config.ApiBase);
+export const APP_BASE = config.get(Config.AppBase);
 
 class App {
   public app: Application;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import {
 } from './lib/controllers';
 import App from './app';
 import { AdminController } from './lib/controllers/admin/adminController';
+import config from 'config';
+import { Config } from '../src/lib/types';
 
 new App(
   [
@@ -19,5 +21,5 @@ new App(
     new ExampleController(),
     new DefaultController(),
   ],
-  3000,
+  config.get(Config.Port),
 );

--- a/src/lib/encrypt-decrypt/encrypt-decrypt.ts
+++ b/src/lib/encrypt-decrypt/encrypt-decrypt.ts
@@ -1,12 +1,13 @@
 import Cryptr from 'cryptr';
-import { Envars } from '../types';
+import { Envars, Config } from '../types';
+import config from 'config';
 
 export class EncryptDecrypt {
   private secret: string;
   private cryptr: Cryptr;
 
   constructor(secret: string) {
-    this.secret = secret || (process.env[Envars.EncryptionSecret] as string);
+    this.secret = secret || config.get(Config.EncryptionSecret);
     this.cryptr = new Cryptr(this.secret);
   }
 

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -1,0 +1,10 @@
+export const enum Config {
+  ClientID = 'client.id',
+  ClientSecret = 'client.secret',
+  EncryptionSecret = 'ecryptionSecret',
+  RedirectUri = 'redirectUri',
+  Scopes = 'scopes',
+  ApiBase = 'api.base',
+  AppBase = 'app.base',
+  Port = 'port',
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,5 @@
-export * from './Controller';
+export * from './controller';
 export * from './db';
 export * from './urlData';
 export * from './envars';
+export * from './config';


### PR DESCRIPTION
This will help us manage environments better don't have to change the API URL or the APP URL again and again. Also updates the docs on how to use it. Will be replacing older code where we use `process.env` to fetch environmental variables.

Example: so for the development environment just create a file name `development.json` in the `config` directory and override the values with like the following:

```
{
    "api": {
        "base": "https://api.dev.snyk.io"
    },
    "app": {
        "base": "https://app.dev.snyk.io"
    },
    "port": 3000
}
```