### PR TITLE
chore: Change oauth2 urls to match upstream changes

### DIFF
--- a/src/lib/utils/OAuth2Strategy/OAuth2Strategy.ts
+++ b/src/lib/utils/OAuth2Strategy/OAuth2Strategy.ts
@@ -15,8 +15,8 @@ export function getOAuth2(nonce: string) {
 
   return new OAuth2Strategy(
     {
-      authorizationURL: `${APP_BASE}/apps/oauth2/authorize?nonce=${nonce}`,
-      tokenURL: `${API_BASE}/v3/apps/oauth2/token`,
+      authorizationURL: `${APP_BASE}/oauth2/authorize?nonce=${nonce}`,
+      tokenURL: `${API_BASE}/oauth2/token`,
       clientID,
       clientSecret,
       callbackURL,


### PR DESCRIPTION
It is convention in OAuth2 to have the various urls at the root under
/oauth2 - this change has been made upstream so this is just a
reflection.