### PR TITLE
chore: Fix linting errors from eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
     "rules": {
         "prettier/prettier": "error",
         "@typescript-eslint/indent": ["error", 2],
-        "@typescript-eslint/no-unused-vars": "warn",
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "next" }],
         "@typescript-eslint/no-inferrable-types": "warn"
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -164,10 +164,10 @@ class App {
     passport.use(getOAuth2(nonce));
     this.app.use(passport.initialize());
     this.app.use(passport.session());
-    passport.serializeUser((user: any, done) => {
+    passport.serializeUser((user: Express.User, done) => {
       done(null, user);
     });
-    passport.deserializeUser((user: any, done) => {
+    passport.deserializeUser((user: Express.User, done) => {
       done(null, user);
     });
   }

--- a/src/lib/controllers/admin/adminController.ts
+++ b/src/lib/controllers/admin/adminController.ts
@@ -11,7 +11,7 @@ import { readFromDb } from '../../utils/db';
  */
 export class AdminController implements Controller {
   // The base URL path for this controller
-  public path: string = '/admin';
+  public path = '/admin';
   // Express router for this controller
   public router: Router = Router();
 

--- a/src/lib/controllers/callback/callbackController.ts
+++ b/src/lib/controllers/callback/callbackController.ts
@@ -13,7 +13,7 @@ import passport from 'passport';
  */
 export class CallbackController implements Controller {
   // The base URL path for this controller
-  public path: string = '/callback';
+  public path = '/callback';
   // Express router for this controller
   public router: Router = Router();
 

--- a/src/lib/controllers/index/indexController.ts
+++ b/src/lib/controllers/index/indexController.ts
@@ -1,5 +1,4 @@
 import type { Controller } from '../../types';
-import { Envars } from '../../types';
 import type { Request, Response, NextFunction } from 'express';
 import { Router } from 'express';
 

--- a/src/lib/controllers/projects/projectsHandlers.ts
+++ b/src/lib/controllers/projects/projectsHandlers.ts
@@ -10,7 +10,7 @@ import { AuthData, Envars } from '../../types';
  * token scopes on what you can and can not access
  * @returns List of user project or an empty array
  */
-export async function getProjectsFromApi() {
+export async function getProjectsFromApi(): Promise<unknown[]> {
   // Read data from DB
   const db = await readFromDb();
   const data = mostRecent(db.installs);

--- a/src/lib/controllers/settings/settingsController.ts
+++ b/src/lib/controllers/settings/settingsController.ts
@@ -10,7 +10,7 @@ import { Router } from 'express';
  */
 export class SettingsController implements Controller {
   // The base URL path for this controller
-  public path: string = '/settings';
+  public path = '/settings';
   // Express router for this controller
   public router: Router = Router();
 

--- a/src/lib/middlewares/reqError.ts
+++ b/src/lib/middlewares/reqError.ts
@@ -5,9 +5,10 @@ import type { ErrorRequestHandler, Request, Response, NextFunction } from 'expre
  * @returns an error handler middleware function
  */
 export function reqError(): ErrorRequestHandler {
+  // @types/express explicitly types this as any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (error: any, req: Request, res: Response, next: NextFunction) => {
     console.error(error);
-    const httpStatusCode: number = error.httpStatusCode || 500;
     const message: string = error.message || 'Internal server error, please try again';
 
     return res.render('error', { errorMessage: message });

--- a/src/lib/utils/api/refreshTokenInterceptor.ts
+++ b/src/lib/utils/api/refreshTokenInterceptor.ts
@@ -14,7 +14,7 @@ import { updateDb } from '../db';
  * for conditional checks
  * @returns Axios request interceptor
  */
-export async function refreshTokenInterceptor(request: AxiosRequestConfig) {
+export async function refreshTokenInterceptor(request: AxiosRequestConfig): Promise<AxiosRequestConfig> {
   // Read the latest data(auth token, refresh token and expiry)
   const db = await readFromDb();
   const data = mostRecent(db.installs);

--- a/src/lib/utils/apiRequests/getUserOrgInfo.ts
+++ b/src/lib/utils/apiRequests/getUserOrgInfo.ts
@@ -7,7 +7,10 @@ import { callSnykApi } from '../api';
  * @param {String} token_type token type which is normally going to be bearer
  * @returns Org data or throws and error
  */
-export async function getUserOrgInfo(access_token: string, token_type: string): Promise<any> {
+export async function getUserOrgInfo(
+  access_token: string,
+  token_type: string,
+): Promise<{ orgId: string; orgName: string }> {
   try {
     const result = await callSnykApi(
       access_token,

--- a/src/lib/utils/apiRequests/refreshAuthToken.ts
+++ b/src/lib/utils/apiRequests/refreshAuthToken.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import qs from 'qs';
 import { GrantType } from '../../types/grantType';
-import { Config, Envars } from '../../types';
+import { AuthData, Config, Envars } from '../../types';
 import { API_BASE } from '../../../app';
 import config from 'config';
 
@@ -12,7 +12,7 @@ import config from 'config';
  * @param {String} refreshToken required to refresh the user auth token when it expires
  * @returns Promise that will return data or throw an error
  */
-export async function refreshAuthToken(refreshToken: string): Promise<any> {
+export async function refreshAuthToken(refreshToken: string): Promise<AuthData> {
   const querystring = qs.stringify({
     grant_type: GrantType.RefreshToken,
     client_id: process.env[Envars.ClientId],
@@ -27,8 +27,8 @@ export async function refreshAuthToken(refreshToken: string): Promise<any> {
       data: querystring,
     });
     return result.data;
-  } catch (error: any) {
-    if (error.response) {
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
       console.log(error.response.data);

--- a/src/lib/utils/db/updateDb.ts
+++ b/src/lib/utils/db/updateDb.ts
@@ -11,16 +11,17 @@ export async function updateDb(oldData: AuthData, newData: AuthData): Promise<bo
   const adapter = new JSONFile<DB>(dbPath);
   const db = new Low<DB>(adapter);
   await db.read();
+  if (db.data == null) {
+    return false;
+  }
   // After reading check if data exists in the database
   const installs = db.data?.installs || [];
 
   const index = installs.findIndex((install) => install.date === oldData.date);
   if (index === -1) return false;
   installs[index] = newData;
-  // If we reached here that means installs array exists
-  // which implies there is definitely data
   // Replace the existing install with new one
-  db.data!.installs = installs;
+  db.data.installs = installs;
   await db.write();
   return true;
 }

--- a/src/lib/utils/db/writeToDb.ts
+++ b/src/lib/utils/db/writeToDb.ts
@@ -8,12 +8,12 @@ import { readFromDb } from './readFromDb';
  * in this case
  * @param {AuthData} data to be written to the DB
  */
-export async function writeToDb(data: AuthData) {
+export async function writeToDb(data: AuthData): Promise<void> {
   const existingData = await readFromDb();
   existingData.installs.push(data);
   // Creates a new DB if one doesn't already exists
   const adapter = new JSONFile(dbPath);
   const db = new Low(adapter);
   db.data = existingData;
-  await db.write();
+  return db.write();
 }

--- a/src/scripts/create-app.ts
+++ b/src/scripts/create-app.ts
@@ -4,14 +4,34 @@ import fs from 'fs';
 import { API_BASE } from '../app';
 import { v4 as uuidv4 } from 'uuid';
 
+type Args = {
+  authToken: string;
+  orgId: string;
+  scopes: string[];
+  name: string;
+};
+type APIResult<T> = {
+  data: {
+    data: {
+      attributes: T;
+    };
+  };
+};
+type CreatedApp = {
+  clientId: string;
+  clientSecret: string;
+  redirectUris: string[];
+  scopes: string;
+};
+
 const args = yargs(process.argv.slice(2)).options({
   authToken: { type: 'string', demandOption: true },
   orgId: { type: 'string', demandOption: true },
   scopes: { type: 'array', demandOption: true },
   name: { type: 'string', demandOption: true },
-}).argv;
+}).argv as Args;
 
-async function createApp(args: any) {
+async function createApp(args: Args) {
   return axios({
     method: 'POST',
     url: `${API_BASE}/v3/orgs/${args.orgId}/apps?version=2021-08-11~experimental`,
@@ -27,7 +47,7 @@ async function createApp(args: any) {
   });
 }
 
-function handleResult(result: any) {
+function handleResult(result: APIResult<CreatedApp>) {
   const { clientId, clientSecret, redirectUris, scopes } = result.data.data.attributes;
   const envContent = `CLIENT_ID=${clientId}
 CLIENT_SECRET=${clientSecret}


### PR DESCRIPTION
Most of these are adding proper type annotations instead of typing
things as `any`.

Added ignores for the next param on expressjs handlers because it is not
used on a lot of endpoints but cannot be omitted.