### PR TITLE
fix: tsconfig overrite type and github action

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          command: monitor
+          command: test
           args: --org-name=${{ secrets.SNYK_ORG }}
       - name: Test
         run: npm run test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
   "strict": true,
   "esModuleInterop": true,
   },
-  "exclude": ["./tests"]
+  "exclude": ["./tests", "./dist"]
 }


### PR DESCRIPTION
- Fixes `tsconfig` issue with overwriting of type files(excluded the `./dist` directory)
- GitHub actions should run `snyk test` instead of only `monitoring` since we are already monitoring current project via GitHub integration