### PR TITLE
fix: passport oauth2 vuln

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This will register your new app with Snyk and create the `.env` file (see below)
 
 2. Once the TypeScript has been compiled to JavaScript(into `./dist` directory) run
 
-    `$ npm run dev` or in watch mode `$ npm run dev:watch`
+    `$ npm run dev`
 
 3. Go to [localhost:3000](http://localhost:3000) to confirm that the app is running successfully
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6223,9 +6223,9 @@
       }
     },
     "passport-oauth2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.0.tgz",
-      "integrity": "sha512-emXPLqLcVEcLFR/QvQXZcwLmfK8e9CqvMgmOFJxcNT3okSFMtUbRRKpY20x5euD+01uHsjjCa07DYboEeLXYiw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
       "requires": {
         "base64url": "3.x.x",
         "oauth": "0.9.x",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lowdb": "github:dankreiger/lowdb#chore/esm-cjs-hybrid-WITH-LIB",
     "luxon": "^2.0.2",
     "passport": "^0.4.1",
-    "passport-oauth2": "^1.6.0",
+    "passport-oauth2": "^1.6.1",
     "qs": "^6.10.1"
   },
   "nodemonConfig": {


### PR DESCRIPTION
- Trying to fix the issue reported with `passport-oauth2`
- Removing `npm run dev:watch` as that is unlikely to work with `javascript` since it requires to be built first. Let the developers figure out for themselves