### PR TITLE
[CVE-2021-44906] Prototype Pollution in minimist 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8083,7 +8083,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "jwt-decode": {


### PR DESCRIPTION
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).

upgrade minimist to version 1.2.6 or later. For example:
```json
"dependencies": {
  "minimist": ">=1.2.6"
}
```
```json
"devDependencies": {
  "minimist": ">=1.2.6"
}
```
