### PR TITLE
chore: remove name from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "snyk-apps-demo",
   "version": "1.0.0",
   "description": "Demo app to demonstrate Snyk Apps feature",
   "main": "index.js",


### PR DESCRIPTION
There was a malicious package published to npm using the same name as this package, it has since been taken down but it still exists in Snyk's vulndb which gives a false positive for anyone scanning this package.

Since this package is not published on npm, nor do we intend to do so, we can remove the name which associates us to that malicious package.

Also regenerate lockfile with a more up to date version of npm.