### PR TITLE
chore: add project snapshot read permission to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ $ npm run create-app -- --authToken=$token --orgId=$id --scopes=$scopes --name="
 
 Ex:
 ```shell
-$ npm run create-app -- --authToken=some-token --orgId=some-snyk-org-id --scopes=org.read org.project.read --name=test-snyk-app
+$ npm run create-app -- --authToken=some-token --orgId=some-snyk-org-id --scopes=org.read org.project.read org.project.snapshot.read --name=test-snyk-app
 ```
 
 or with `redirectUris`
 
 ```shell
-$ npm run create-app -- --authToken=some-token --orgId=some-snyk-org-id --redirect-uris=https://your-domain/callback --scopes=org.read org.project.read --name=test-snyk-app
+$ npm run create-app -- --authToken=some-token --orgId=some-snyk-org-id --redirect-uris=https://your-domain/callback --scopes=org.read org.project.read org.project.snapshot.read --name=test-snyk-app
 ```
 
 (note the extra `--` between `create-app` and the parameters)


### PR DESCRIPTION
A new permission has been added for more granular control, the get projects endpoint requires this new permission.

Existing apps that already had the project.read permission have been automatically granted this new permission already so this is just for newly created apps.