### PR TITLE
fix: exclude test folders from being scanned by Snyk Code

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,6 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
-ignore: {}
-patch: {}
+version: v1.22.1
+
+# exclude test files from being scanned by Snyk Code
+exclude:
+  code:
+    - tests/**


### PR DESCRIPTION
Snyk Code scans everything by default, but test files aren’t relevant.