### PR TITLE
Feat: cleanup versions

### DIFF
--- a/src/lib/types/apiVersion.ts
+++ b/src/lib/types/apiVersion.ts
@@ -5,7 +5,6 @@ export const enum API {
 
 export const enum APIVersion {
   // Experimental API versions
-  V20210811exp = '2021-08-11~experimental',
   V20220216exp = '2022-02-16~experimental',
 
   // GA API versions

--- a/src/lib/types/apiVersion.ts
+++ b/src/lib/types/apiVersion.ts
@@ -4,9 +4,6 @@ export const enum API {
 }
 
 export const enum APIVersion {
-  // Experimental API versions
-  V20220216exp = '2022-02-16~experimental',
-
   // GA API versions
   V20230529 = '2023-05-29',
   V20231103 = '2023-11-03',

--- a/src/lib/utils/OAuth2Strategy/OAuth2Strategy.ts
+++ b/src/lib/utils/OAuth2Strategy/OAuth2Strategy.ts
@@ -1,7 +1,7 @@
 import type { Request } from 'express';
 import { writeToDb } from '../db';
 import { EncryptDecrypt } from '../encrypt-decrypt';
-import { APIVersion, AuthData, Config, Envars } from '../../types';
+import { AuthData, Config, Envars } from '../../types';
 import { API_BASE, APP_BASE } from '../../../app';
 import { getAppOrgs } from '../apiRequests';
 import config from 'config';
@@ -38,10 +38,9 @@ export function getOAuth2(): OAuth2Strategy {
   const clientSecret = process.env[Envars.ClientSecret] as string;
   const callbackURL = process.env[Envars.RedirectUri] as string;
 
-  // Note: the value of version being manually added
   return new OAuth2Strategy(
     {
-      authorizationURL: `${APP_BASE}${config.get(Config.AuthURL)}?version=${APIVersion.V20210811exp}`,
+      authorizationURL: `${APP_BASE}${config.get(Config.AuthURL)}`,
       tokenURL: `${API_BASE}${config.get(Config.TokenURL)}`,
       clientID: clientID,
       clientSecret: clientSecret,

--- a/src/lib/utils/apiRequests/getAppOrg.ts
+++ b/src/lib/utils/apiRequests/getAppOrg.ts
@@ -19,7 +19,7 @@ export async function getAppOrgs(tokenType: string, accessToken: string): Promis
       accessToken,
     )({
       method: 'GET',
-      url: `/orgs?version=${APIVersion.V20220216exp}`,
+      url: `/orgs?version=${APIVersion.V20231103}`,
     });
 
     return {


### PR DESCRIPTION
### remove version from authorizationURL

This param was never used upstream, however until recently it was required for historic reasons. We have now changed that so it is no longer required and thus superfluous. Not specifying it will improve compatibility with other OAuth2 libraries.


### call GA version of get /orgs endpoint

We shouldn't be setting an example of calling experimental endpoints, this endpoint is in GA so call that instead.